### PR TITLE
[topview] fix x coordinate

### DIFF
--- a/Assets/Movement.cs
+++ b/Assets/Movement.cs
@@ -87,12 +87,29 @@ public class Movement : MonoBehaviour
         StartCoroutine(OnMoveToY());
     }
 
+    private float findClosetValue(float val) {
+        float[] arr = {-2, 0, 2};
+        float dest = val;
+        float minDiff = 10000;
+        for (int i=0; i<arr.Length; i++)
+        {
+            float diff = Mathf.Abs(val - arr[i]);
+            if(diff < minDiff)
+            {
+                minDiff = diff;
+                dest = arr[i];
+            }
+        }
+        return dest;
+    }
+
     private IEnumerator OnMoveToX(int direction)
     {
         float current = 0;
         float percent = 0;
         float start = transform.position.x;
         float end = transform.position.x + direction * moveXWidth;
+        end = findClosetValue(end);
 
         isXMove = true;
 

--- a/Assets/TopviewPlayerController.cs
+++ b/Assets/TopviewPlayerController.cs
@@ -36,14 +36,14 @@ public class TopviewPlayerController : MonoBehaviour
             OnPCPlatform();
         }
         // detect obstacle
-        if (Physics.Raycast(transform.position, Vector3.left, out hit, Mathf.Infinity, LayerMask.GetMask("Obstacle")))
+        if (Physics.Raycast(transform.position, Vector3.left, out hit, 2.0f, LayerMask.GetMask("Obstacle")))
         {
             isLeftObstacle = true;
             Debug.Log("Hit obstacle " + hit.collider.gameObject.name);
             Debug.DrawRay(transform.position, Vector3.left* hit.distance, Color.red);
         }
         else isLeftObstacle = false;
-        if (Physics.Raycast(transform.position, Vector3.right, out hit, Mathf.Infinity, LayerMask.GetMask("Obstacle")))
+        if (Physics.Raycast(transform.position, Vector3.right, out hit, 2.0f, LayerMask.GetMask("Obstacle")))
         {
             isRightObstacle = true;
             Debug.Log("Hit obstacle " + hit.collider.gameObject.name);


### PR DESCRIPTION
탑뷰에서 진짜로 x좌표 [-2, 0, 2]를 벗어난다면 제일 가까운 x 좌표에 위치하도록 옮겨버림.
그러니까 애매하게 이상한데로 가서 달리진 않네요.
이제 raycast로 검출되었는데 움직이는 이유를 찾아야만 한다눙 (raycast를 몸전체 길이 중 다양한 위치에서 싸볼까 싶기도 하고 _~_)
굿 아이디어였음~
